### PR TITLE
feat: implement session deletion

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -42,12 +42,24 @@ async function setSessionCookie(sessionToken, response) {
   response.setHeader("Set-Cookie", setCookie);
 }
 
+async function clearSessionCookie(response) {
+  const setCookie = cookie.serialize("session_id", "invalid", {
+    path: "/",
+    maxAge: -1,
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+  });
+
+  response.setHeader("Set-Cookie", setCookie);
+}
+
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
     onError: onErrorHandler,
   },
   setSessionCookie,
+  clearSessionCookie,
 };
 
 export default controller;

--- a/models/session.js
+++ b/models/session.js
@@ -86,10 +86,35 @@ async function renew(sessionId) {
   }
 }
 
+async function expireById(sessionId) {
+  const expiredSessionObject = await runUpdateQuery(sessionId);
+  return expiredSessionObject;
+
+  async function runUpdateQuery(sessionId) {
+    const results = await database.query({
+      text: `
+        UPDATE
+          sessions
+        SET
+          expires_at = expires_at - interval '1 year',
+          updated_at = NOW()
+        WHERE
+          id = $1
+        RETURNING
+          *
+      `,
+      values: [sessionId],
+    });
+
+    return results.rows[0];
+  }
+}
+
 const session = {
   create,
   EXPIRATION_IN_MILLISECONDS,
   renew,
+  expireById,
   findOneValidByToken,
 };
 

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -1,12 +1,13 @@
 import { createRouter } from "next-connect";
 
-import controller from "infra/controller";
+import controller from "infra/controller.js";
 import authentication from "models/authentication.js";
 import session from "models/session.js";
 
 const router = createRouter();
 
 router.post(postHandler);
+router.delete(deleteHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -23,4 +24,14 @@ async function postHandler(request, response) {
   controller.setSessionCookie(newSession.token, response);
 
   response.status(201).json(newSession);
+}
+
+async function deleteHandler(request, response) {
+  const sessionToken = request.cookies.session_id;
+
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const expiredSession = await session.expireById(sessionObject.id);
+  controller.clearSessionCookie(response);
+
+  return response.status(200).json(expiredSession);
 }

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -1,0 +1,143 @@
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+import orchestrator from "tests/orchestrator.js";
+import session from "models/session.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("DELETE /api/v1/sessions", () => {
+  describe("Default user", () => {
+    test("With nonexistent session", async () => {
+      const nonexistentSToken =
+        "be4e25e3629b5aa59bc09e27d06d2b4a8eaeab61ae8a720e1c7f8fa6bebcab39d77bf015ae316d852e5fc00ed95cf1de";
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${nonexistentSToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILLISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser();
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: sessionObject.id,
+        token: sessionObject.token,
+        user_id: sessionObject.user_id,
+        expires_at: responseBody.expires_at,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(
+        responseBody.expires_at < sessionObject.expires_at.toISOString(),
+      ).toBe(true);
+
+      expect(
+        responseBody.updated_at > sessionObject.updated_at.toISOString(),
+      ).toBe(true);
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
+
+      // Double check assertions
+
+      const doubleCheckResponse = await fetch(
+        "http://localhost:3000/api/v1/user",
+        {
+          headers: {
+            Cookie: `session_id=${sessionObject.token}`,
+          },
+        },
+      );
+
+      expect(doubleCheckResponse.status).toBe(401);
+
+      const doubleCheckResponseBody = await doubleCheckResponse.json();
+
+      expect(doubleCheckResponseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds support for logging out users by implementing a `DELETE /api/v1/sessions` endpoint. The main changes include backend logic for expiring sessions, clearing the session cookie, API route handling, and comprehensive integration tests to ensure correct behavior for various session states.

**Session expiration and cookie management:**
- Added `expireById` to the `session` model to expire a session in the database by setting its expiration date to the past.
- Implemented `clearSessionCookie` in `infra/controller.js` to invalidate the `session_id` cookie on logout.

**API endpoint implementation:**
- Added `deleteHandler` to handle `DELETE` requests in `pages/api/v1/sessions/index.js`, which finds and expires the session, clears the cookie, and returns the expired session object.
- Registered the new `DELETE` handler in the sessions API route.

**Testing:**
- Introduced integration tests for `DELETE /api/v1/sessions`, covering scenarios for nonexistent, expired, and valid sessions, including cookie invalidation and session state verification.