### PR TITLE
feat: invalidate session cookie on unauthorized error

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -14,11 +14,13 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-  if (
-    error instanceof ValidationError ||
-    error instanceof NotFoundError ||
-    error instanceof UnauthorizedError
-  ) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
+
     return response.status(error.statusCode).json(error);
   }
 

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -93,6 +93,19 @@ describe("GET /api/v1/user", () => {
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
       });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
     });
 
     test("With expired session", async () => {
@@ -123,6 +136,19 @@ describe("GET /api/v1/user", () => {
         message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
   });


### PR DESCRIPTION
This pull request improves error handling for unauthorized requests by ensuring that the session cookie is properly cleared when an `UnauthorizedError` occurs. It also adds integration tests to verify that the session cookie is invalidated in these scenarios.

**Error handling improvements:**

* Updated the `onErrorHandler` in `infra/controller.js` to call `clearSessionCookie(response)` when handling an `UnauthorizedError`, ensuring the session is invalidated on unauthorized access.

**Testing enhancements:**

* Added assertions in `tests/integration/api/v1/user/get.test.js` to verify that the `session_id` cookie is set to "invalid" with `maxAge: -1` (i.e., cleared) when an unauthorized or expired session is encountered. [[1]](diffhunk://#diff-8f4a0c1d7ab5ab4482895acb011594e3d0f7f5ad1206d124519cd35b1aa3df94R96-R108) [[2]](diffhunk://#diff-8f4a0c1d7ab5ab4482895acb011594e3d0f7f5ad1206d124519cd35b1aa3df94R140-R152)